### PR TITLE
Reproduce maps with noise seeding.

### DIFF
--- a/hex_map.pyde
+++ b/hex_map.pyde
@@ -17,6 +17,7 @@ outline_color = (0, 0, 0)
 #############
 # Noise Variables
 #############
+noise_seed = int(random(2**31))
 noise_loc_mod = 4
 noise_scale = .02
 noise_max = 120
@@ -132,6 +133,8 @@ def setup():
     map_height = int(1.5 * imgh / (.86 * hexagon_size))
     map_width =  int(1.5 * imgw / (hexagon_size * 3))
     
+    noiseSeed(noise_seed)
+
     hex_map = []
     for mh in range(map_height):
         hex_map.append([])
@@ -174,7 +177,5 @@ def setup():
                     
                 draw_hexagon(c[0], c[1], hexagon_size, noise_height)
     
-    
-    seed = int(random(10000))
-    
-    save('Examples/Best/%s.png' % seed)
+    print("SEED USED: %s" % noise_seed)    
+    save('Examples/Best/%s.png' % noise_seed)


### PR DESCRIPTION
I added noise_seed, which allows reproducing the same map again and again by passing in a seed  (or automatically generating a new one) - the file is saved with the seed, and the seed is printed to console.